### PR TITLE
fix:discussion was not updated correctly after post approval

### DIFF
--- a/src/Listener/ApproveContent.php
+++ b/src/Listener/ApproveContent.php
@@ -63,7 +63,7 @@ class ApproveContent
 
         if ($post->number == 1) {
             $post->discussion->is_approved = true;
-            $post->discussion->save();
         }
+        $post->discussion->save();
     }
 }


### PR DESCRIPTION
I found that the comments count and last post of discussion was not updated correctly after post approval, because the following code was applied to first post only:

`$post->discussion->save();`