### PR TITLE
More specific unnaproved opacity

### DIFF
--- a/less/forum/extension.less
+++ b/less/forum/extension.less
@@ -1,6 +1,8 @@
 .Post--unapproved {
-  .Post-header,
   .Post-body,
+  .PostUser-avatar,
+  .PostUser > h3 > a,
+  .PostUser > .UserOnline,
   .EventPost-icon,
   .EventPost-info {
     opacity: 0.5;


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/926

This change leaves the UserBadges and most of the .Post-header intact. I'm not sure if you actually would want to forcibly fade all header items.