### PR TITLE
Fix conflicts with other extension visibility scoping

### DIFF
--- a/src/Access/ScopePrivateDiscussionVisibility.php
+++ b/src/Access/ScopePrivateDiscussionVisibility.php
@@ -21,7 +21,7 @@ class ScopePrivateDiscussionVisibility
     public function __invoke(User $actor, Builder $query)
     {
         // All statements need to be wrapped in an orWhere, since we're adding a
-        // subset of private posts that should be visible, not restricting the visible
+        // subset of private discussions that should be visible, not restricting the visible
         // set.
         $query->orWhere(function ($query) use ($actor) {
             // Show empty/private discussions if they require approval and they are

--- a/src/Access/ScopePrivateDiscussionVisibility.php
+++ b/src/Access/ScopePrivateDiscussionVisibility.php
@@ -29,7 +29,7 @@ class ScopePrivateDiscussionVisibility
             // approve posts.
             $query->where('discussions.is_approved', 0);
 
-            if (!$actor->hasPermission('discussion.approvePosts')) {
+            if (! $actor->hasPermission('discussion.approvePosts')) {
                 $query->where(function (Builder $query) use ($actor) {
                     $query->where('discussions.user_id', $actor->id)
                         ->orWhere(function ($query) use ($actor) {

--- a/src/Access/ScopePrivateDiscussionVisibility.php
+++ b/src/Access/ScopePrivateDiscussionVisibility.php
@@ -20,18 +20,23 @@ class ScopePrivateDiscussionVisibility
      */
     public function __invoke(User $actor, Builder $query)
     {
-        // Show empty/private discussions if they require approval and they are
-        // authored by the current user, or the current user has permission to
-        // approve posts.
-        $query->where('discussions.is_approved', 0);
+        // All statements need to be wrapped in an orWhere, since we're adding a
+        // subset of private posts that should be visible, not restricting the visible
+        // set.
+        $query->orWhere(function ($query) use ($actor) {
+            // Show empty/private discussions if they require approval and they are
+            // authored by the current user, or the current user has permission to
+            // approve posts.
+            $query->where('discussions.is_approved', 0);
 
-        if (! $actor->hasPermission('discussion.approvePosts')) {
-            $query->where(function (Builder $query) use ($actor) {
-                $query->where('discussions.user_id', $actor->id)
-                    ->orWhere(function ($query) use ($actor) {
-                        $query->whereVisibleTo($actor, 'approvePosts');
-                    });
-            });
-        }
+            if (!$actor->hasPermission('discussion.approvePosts')) {
+                $query->where(function (Builder $query) use ($actor) {
+                    $query->where('discussions.user_id', $actor->id)
+                        ->orWhere(function ($query) use ($actor) {
+                            $query->whereVisibleTo($actor, 'approvePosts');
+                        });
+                });
+            }
+        });
     }
 }

--- a/src/Access/ScopePrivatePostVisibility.php
+++ b/src/Access/ScopePrivatePostVisibility.php
@@ -21,17 +21,22 @@ class ScopePrivatePostVisibility
      */
     public function __invoke(User $actor, Builder $query)
     {
-        // Show private posts if they require approval and they are
-        // authored by the current user, or the current user has permission to
-        // approve posts.
-        $query->where('posts.is_approved', 0);
+        // All statements need to be wrapped in an orWhere, since we're adding a
+        // subset of private posts that should be visible, not restricting the visible
+        // set.
+        $query->orWhere(function ($query) use ($actor) {
+            // Show private posts if they require approval and they are
+            // authored by the current user, or the current user has permission to
+            // approve posts.
+            $query->where('posts.is_approved', 0);
 
-        if (! $actor->hasPermission('discussion.approvePosts')) {
-            $query->where(function (Builder $query) use ($actor) {
-                $query->where('posts.user_id', $actor->id)
-                    ->orWhereExists($this->discussionWhereCanApprovePosts($actor));
-            });
-        }
+            if (! $actor->hasPermission('discussion.approvePosts')) {
+                $query->where(function (Builder $query) use ($actor) {
+                    $query->where('posts.user_id', $actor->id)
+                        ->orWhereExists($this->discussionWhereCanApprovePosts($actor));
+                });
+            }
+    }   );
     }
 
     private function discussionWhereCanApprovePosts(User $actor)

--- a/src/Access/ScopePrivatePostVisibility.php
+++ b/src/Access/ScopePrivatePostVisibility.php
@@ -36,7 +36,7 @@ class ScopePrivatePostVisibility
                         ->orWhereExists($this->discussionWhereCanApprovePosts($actor));
                 });
             }
-    }   );
+        });
     }
 
     private function discussionWhereCanApprovePosts(User $actor)


### PR DESCRIPTION
**Fixes flarum/core#2798**

All top-level statements need to be wrapped in an orWhere, since we're adding a
subset of private posts that should be visible, not restricting the visible set.